### PR TITLE
Make the packaging of the function much more efficient

### DIFF
--- a/packages/joke/joke/build.sh
+++ b/packages/joke/joke/build.sh
@@ -2,7 +2,5 @@
 
 set -e
 
-virtualenv virtualenv
-source virtualenv/bin/activate
-pip install -r requirements.txt
-deactivate
+virtualenv --without-pip virtualenv
+pip install -r requirements.txt --target virtualenv/lib/python3.9/site-packages


### PR DESCRIPTION
This reduces the packaged zip size from 5.4M to 68K by not including all the unncesssary tooling that's usually copied into virtualenv. We just need to actual dependencies (at least for simple cases like this).